### PR TITLE
feat: 11 - added 90 degree rotations

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,12 +37,11 @@ class _MyHomePageState extends State<MyHomePage> {
           title: Text(widget.title),
         ),
         body: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(6.0),
-            child: CropImage(
-              controller: controller,
-              image: Image.asset('assets/08272011229.jpg'),
-            ),
+          child: CropImage(
+            controller: controller,
+            image: Image.asset('assets/08272011229.jpg'),
+            paddingSize: 25.0,
+            alwaysMove: true,
           ),
         ),
         bottomNavigationBar: _buildButtons(),
@@ -55,13 +54,22 @@ class _MyHomePageState extends State<MyHomePage> {
           IconButton(
             icon: const Icon(Icons.close),
             onPressed: () {
-              controller.aspectRatio = 1.0;
+              controller.rotation = CropRotation.noon;
               controller.crop = const Rect.fromLTRB(0.1, 0.1, 0.9, 0.9);
+              controller.aspectRatio = 1.0;
             },
           ),
           IconButton(
             icon: const Icon(Icons.aspect_ratio),
             onPressed: _aspectRatios,
+          ),
+          IconButton(
+            icon: const Icon(Icons.rotate_90_degrees_ccw_outlined),
+            onPressed: _rotateLeft,
+          ),
+          IconButton(
+            icon: const Icon(Icons.rotate_90_degrees_cw_outlined),
+            onPressed: _rotateRight,
           ),
           TextButton(
             onPressed: _finished,
@@ -77,6 +85,11 @@ class _MyHomePageState extends State<MyHomePage> {
         return SimpleDialog(
           title: const Text('Select aspect ratio'),
           children: [
+            // special case: no aspect ratio
+            SimpleDialogOption(
+              onPressed: () => Navigator.pop(context, -1.0),
+              child: const Text('free'),
+            ),
             SimpleDialogOption(
               onPressed: () => Navigator.pop(context, 1.0),
               child: const Text('square'),
@@ -98,10 +111,14 @@ class _MyHomePageState extends State<MyHomePage> {
       },
     );
     if (value != null) {
-      controller.aspectRatio = value;
+      controller.aspectRatio = value == -1 ? null : value;
       controller.crop = const Rect.fromLTRB(0.1, 0.1, 0.9, 0.9);
     }
   }
+
+  Future<void> _rotateLeft() async => controller.rotateLeft();
+
+  Future<void> _rotateRight() async => controller.rotateRight();
 
   Future<void> _finished() async {
     final image = await controller.croppedImage();

--- a/lib/crop_image.dart
+++ b/lib/crop_image.dart
@@ -1,2 +1,3 @@
 export 'package:crop_image/src/crop_controller.dart';
 export 'package:crop_image/src/crop_image.dart';
+export 'package:crop_image/src/crop_rotation.dart';

--- a/lib/src/crop_controller.dart
+++ b/lib/src/crop_controller.dart
@@ -1,13 +1,13 @@
 import 'dart:ui' as ui;
 
-import 'package:crop_image/crop_image.dart';
+import 'crop_rect.dart';
+import 'crop_rotation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
 /// A controller to control the functionality of [CropImage].
-class CropController extends ValueNotifier<_CropControllerValue> {
+class CropController extends ValueNotifier<CropControllerValue> {
   /// Aspect ratio of the image (width / height).
   ///
   /// The [crop] rectangle will be adjusted to fit this ratio.
@@ -15,12 +15,19 @@ class CropController extends ValueNotifier<_CropControllerValue> {
   double? get aspectRatio => value.aspectRatio;
 
   set aspectRatio(double? newAspectRatio) {
-    if (newAspectRatio != null)
+    if (newAspectRatio != null) {
       value = value.copyWith(
-          aspectRatio: newAspectRatio,
-          crop: _adjustRatio(value.crop, newAspectRatio));
-    else
-      value = _CropControllerValue(null, value.crop);
+        aspectRatio: newAspectRatio,
+        crop: _adjustRatio(value.crop, newAspectRatio),
+      );
+    } else {
+      value = CropControllerValue(
+        null,
+        value.crop,
+        value.rotation,
+        value.minimumImageSize,
+      );
+    }
     notifyListeners();
   }
 
@@ -37,10 +44,48 @@ class CropController extends ValueNotifier<_CropControllerValue> {
   Rect get crop => value.crop;
 
   set crop(Rect newCrop) {
-    if (value.aspectRatio != null)
+    if (value.aspectRatio != null) {
       value = value.copyWith(crop: _adjustRatio(newCrop, value.aspectRatio!));
-    else
+    } else {
       value = value.copyWith(crop: newCrop);
+    }
+    notifyListeners();
+  }
+
+  CropRotation get rotation => value.rotation;
+
+  set rotation(CropRotation rotation) {
+    value = value.copyWith(rotation: rotation);
+    notifyListeners();
+  }
+
+  //FIXME: should be able to deal with aspectRatio
+  void rotateRight() {
+    value = CropControllerValue(
+      null,
+      Rect.fromCenter(
+        center: Offset(1 - crop.center.dy, crop.center.dx),
+        width: crop.height,
+        height: crop.width,
+      ),
+      value.rotation.rotateRight,
+      value.minimumImageSize,
+    );
+    notifyListeners();
+  }
+
+  //FIXME: should be able to deal with aspectRatio
+  void rotateLeft() {
+    value = CropControllerValue(
+      null,
+      Rect.fromCenter(
+        center: Offset(crop.center.dy, 1 - crop.center.dx),
+        width: crop.height,
+        height: crop.width,
+      ),
+      value.rotation.rotateLeft,
+      value.minimumImageSize,
+    );
     notifyListeners();
   }
 
@@ -56,16 +101,17 @@ class CropController extends ValueNotifier<_CropControllerValue> {
   Rect get cropSize => value.crop.multiply(_bitmapSize);
 
   set cropSize(Rect newCropSize) {
-    if (value.aspectRatio != null)
+    if (value.aspectRatio != null) {
       value = value.copyWith(
           crop: _adjustRatio(
               newCropSize.divide(_bitmapSize), value.aspectRatio!));
-    else
+    } else {
       value = value.copyWith(crop: newCropSize.divide(_bitmapSize));
+    }
     notifyListeners();
   }
 
-  late ui.Image _bitmap;
+  ui.Image? _bitmap;
   late Size _bitmapSize;
 
   @internal
@@ -75,6 +121,8 @@ class CropController extends ValueNotifier<_CropControllerValue> {
     aspectRatio = aspectRatio; // force adjustment
     notifyListeners();
   }
+
+  ui.Image? getImage() => _bitmap;
 
   /// A controller for a [CropImage] widget.
   ///
@@ -86,6 +134,8 @@ class CropController extends ValueNotifier<_CropControllerValue> {
   CropController({
     double? aspectRatio,
     Rect defaultCrop = const Rect.fromLTWH(0, 0, 1, 1),
+    CropRotation rotation = CropRotation.noon,
+    double minimumImageSize = 100,
   })  : assert(aspectRatio != 0, 'aspectRatio cannot be zero'),
         assert(defaultCrop.left >= 0 && defaultCrop.left <= 1,
             'left should be 0..1'),
@@ -99,10 +149,15 @@ class CropController extends ValueNotifier<_CropControllerValue> {
             'left must be less than right'),
         assert(defaultCrop.top < defaultCrop.bottom,
             'top must be less than bottom'),
-        super(_CropControllerValue(aspectRatio, defaultCrop));
+        super(CropControllerValue(
+          aspectRatio,
+          defaultCrop,
+          rotation,
+          minimumImageSize,
+        ));
 
-  /// Creates a controller for a [CropImage] widget from an initial [_CropControllerValue].
-  CropController.fromValue(_CropControllerValue value) : super(value);
+  /// Creates a controller for a [CropImage] widget from an initial [CropControllerValue].
+  CropController.fromValue(CropControllerValue value) : super(value);
 
   Rect _adjustRatio(Rect rect, double aspectRatio) {
     final width = rect.width * _bitmapSize.width;
@@ -118,21 +173,119 @@ class CropController extends ValueNotifier<_CropControllerValue> {
 
   /// Returns the bitmap cropped with the current crop rectangle.
   ///
+  /// [maxSize] is the maximum width or height you want.
   /// You can provide the [quality] used in the resizing operation.
   /// Returns an [ui.Image] asynchronously.
-  Future<ui.Image> croppedBitmap(
-      {ui.FilterQuality quality = FilterQuality.high}) async {
-    final pictureRecorder = ui.PictureRecorder();
-    Canvas(pictureRecorder).drawImageRect(
-      _bitmap,
-      cropSize,
-      Offset.zero & cropSize.size,
+  Future<ui.Image> croppedBitmap({
+    final double? maxSize,
+    final ui.FilterQuality quality = FilterQuality.high,
+  }) async =>
+      _getCroppedBitmap(
+        maxSize: maxSize,
+        quality: quality,
+        crop: crop,
+        rotation: value.rotation,
+        image: _bitmap!,
+      );
+
+  /// Returns the bitmap cropped with parameters.
+  ///
+  /// [maxSize] is the maximum width or height you want.
+  /// The [crop] `Rect` is normalized to (0, 0) x (1, 1).
+  /// You can provide the [quality] used in the resizing operation.
+  static Future<ui.Image> _getCroppedBitmap({
+    final double? maxSize,
+    final ui.FilterQuality quality = FilterQuality.high,
+    required final Rect crop,
+    required final CropRotation rotation,
+    required final ui.Image image,
+  }) async {
+    final ui.PictureRecorder pictureRecorder = ui.PictureRecorder();
+    final Canvas canvas = Canvas(pictureRecorder);
+
+    final bool tilted = rotation.isTilted;
+    final double cropWidth;
+    final double cropHeight;
+    if (tilted) {
+      cropWidth = crop.width * image.height;
+      cropHeight = crop.height * image.width;
+    } else {
+      cropWidth = crop.width * image.width;
+      cropHeight = crop.height * image.height;
+    }
+    // factor between the full size and the maxSize constraint.
+    double factor = 1;
+    if (maxSize != null) {
+      if (cropWidth > maxSize || cropHeight > maxSize) {
+        if (cropWidth >= cropHeight) {
+          factor = maxSize / cropWidth;
+        } else {
+          factor = maxSize / cropHeight;
+        }
+      }
+    }
+
+    // just checking
+    canvas.drawRect(
+      Rect.fromLTWH(0, 0, cropWidth * factor, cropHeight * factor),
+      Paint()
+        ..color = Colors.red
+        ..style = PaintingStyle.fill,
+    );
+
+    final Offset cropCenter = rotation.getRotatedOffset(
+      crop.center,
+      image.width.toDouble(),
+      image.height.toDouble(),
+    );
+
+    final double alternateWidth = tilted ? cropHeight : cropWidth;
+    final double alternateHeight = tilted ? cropWidth : cropHeight;
+    if (rotation != CropRotation.noon) {
+      canvas.save();
+      final double x = alternateWidth / 2 * factor;
+      final double y = alternateHeight / 2 * factor;
+      canvas.translate(x, y);
+      canvas.rotate(rotation.radians);
+      if (rotation == CropRotation.threeOClock) {
+        canvas.translate(
+          -y,
+          -cropWidth * factor + x,
+        );
+      } else if (rotation == CropRotation.nineOClock) {
+        canvas.translate(
+          y - cropHeight * factor,
+          -x,
+        );
+      } else if (rotation == CropRotation.sixOClock) {
+        canvas.translate(-x, -y);
+      }
+    }
+
+    canvas.drawImageRect(
+      image,
+      Rect.fromCenter(
+        center: cropCenter,
+        width: alternateWidth,
+        height: alternateHeight,
+      ),
+      Rect.fromLTWH(
+        0,
+        0,
+        alternateWidth * factor,
+        alternateHeight * factor,
+      ),
       Paint()..filterQuality = quality,
     );
+
+    if (rotation != CropRotation.noon) {
+      canvas.restore();
+    }
+
     //FIXME Picture.toImage() crashes on Flutter Web with the HTML renderer. Use CanvasKit or avoid this operation for now. https://github.com/flutter/engine/pull/20750
     return await pictureRecorder
         .endRecording()
-        .toImage(cropSize.width.round(), cropSize.height.round());
+        .toImage((cropWidth * factor).round(), (cropHeight * factor).round());
   }
 
   /// Returns the image cropped with the current crop rectangle.
@@ -149,30 +302,51 @@ class CropController extends ValueNotifier<_CropControllerValue> {
 }
 
 @immutable
-class _CropControllerValue {
+class CropControllerValue {
   final double? aspectRatio;
   final Rect crop;
+  final CropRotation rotation;
+  final double minimumImageSize;
 
-  const _CropControllerValue(this.aspectRatio, this.crop);
+  const CropControllerValue(
+    this.aspectRatio,
+    this.crop,
+    this.rotation,
+    this.minimumImageSize,
+  );
 
-  _CropControllerValue copyWith({double? aspectRatio, Rect? crop}) =>
-      _CropControllerValue(
+  CropControllerValue copyWith({
+    double? aspectRatio,
+    Rect? crop,
+    CropRotation? rotation,
+    double? minimumImageSize,
+  }) =>
+      CropControllerValue(
         aspectRatio ?? this.aspectRatio,
         crop ?? this.crop,
+        rotation ?? this.rotation,
+        minimumImageSize ?? this.minimumImageSize,
       );
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other))
+    if (identical(this, other)) {
       return true;
-    else
-      return (other is _CropControllerValue &&
-          other.aspectRatio == aspectRatio &&
-          other.crop == crop);
+    }
+    return other is CropControllerValue &&
+        other.aspectRatio == aspectRatio &&
+        other.crop == crop &&
+        other.rotation == rotation &&
+        other.minimumImageSize == minimumImageSize;
   }
 
   @override
-  int get hashCode => hashValues(aspectRatio.hashCode, crop.hashCode);
+  int get hashCode => Object.hash(
+        aspectRatio.hashCode,
+        crop.hashCode,
+        rotation.hashCode,
+        minimumImageSize.hashCode,
+      );
 }
 
 /// Provides the given [ui.Image] object as an [Image].
@@ -207,23 +381,4 @@ class UiImageProvider extends ImageProvider<UiImageProvider> {
 
   @override
   int get hashCode => image.hashCode;
-}
-
-@internal
-extension RectExtensions on Rect {
-  @internal
-  Rect multiply(Size size) => Rect.fromLTRB(
-        left * size.width,
-        top * size.height,
-        right * size.width,
-        bottom * size.height,
-      );
-
-  @internal
-  Rect divide(Size size) => Rect.fromLTRB(
-        left / size.width,
-        top / size.height,
-        right / size.width,
-        bottom / size.height,
-      );
 }

--- a/lib/src/crop_grid.dart
+++ b/lib/src/crop_grid.dart
@@ -1,10 +1,13 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'crop_rect.dart';
 
+/// Crop Grid with invisible border, for better touch detection.
 class CropGrid extends StatelessWidget {
   final Rect crop;
   final Color gridcolor;
+  final double paddingSize;
   final double cornerSize;
   final double thinWidth;
   final double thickWidth;
@@ -17,6 +20,7 @@ class CropGrid extends StatelessWidget {
     Key? key,
     required this.crop,
     required this.gridcolor,
+    required this.paddingSize,
     required this.cornerSize,
     required this.thinWidth,
     required this.thickWidth,
@@ -39,14 +43,15 @@ class _CropGridPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    final Rect full = Offset.zero & size;
-    final Rect bounds = Rect.fromLTRB(
-      grid.crop.left * full.width,
-      grid.crop.top * full.height,
-      grid.crop.right * full.width,
-      grid.crop.bottom * full.height,
+    final Size imageSize = Size(
+      size.width - 2 * grid.paddingSize,
+      size.height - 2 * grid.paddingSize,
     );
-    grid.onSize(size);
+    final Rect full = Offset(grid.paddingSize, grid.paddingSize) & imageSize;
+    final Rect bounds = grid.crop
+        .multiply(imageSize)
+        .translate(grid.paddingSize, grid.paddingSize);
+    grid.onSize(imageSize);
 
     canvas.save();
     canvas.clipRect(bounds, clipOp: ClipOp.difference);

--- a/lib/src/crop_rect.dart
+++ b/lib/src/crop_rect.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:meta/meta.dart';
+
+@internal
+extension RectExtensions on Rect {
+  @internal
+  Rect multiply(Size size) => Rect.fromLTRB(
+        left * size.width,
+        top * size.height,
+        right * size.width,
+        bottom * size.height,
+      );
+
+  @internal
+  Rect divide(Size size) => Rect.fromLTRB(
+        left / size.width,
+        top / size.height,
+        right / size.width,
+        bottom / size.height,
+      );
+}

--- a/lib/src/crop_rotation.dart
+++ b/lib/src/crop_rotation.dart
@@ -1,0 +1,119 @@
+import 'dart:math' as math;
+import 'dart:ui';
+
+/// 90 degree rotations.
+enum CropRotation {
+  noon,
+  threeOClock,
+  sixOClock,
+  nineOClock,
+}
+
+extension CropRotationExtension on CropRotation {
+  /// Returns the rotation in radians cw.
+  double get radians {
+    switch (this) {
+      case CropRotation.noon:
+        return 0;
+      case CropRotation.threeOClock:
+        return math.pi / 2;
+      case CropRotation.sixOClock:
+        return math.pi;
+      case CropRotation.nineOClock:
+        return 3 * math.pi / 2;
+    }
+  }
+
+  /// Returns the rotation in degrees cw.
+  int get degrees {
+    switch (this) {
+      case CropRotation.noon:
+        return 0;
+      case CropRotation.threeOClock:
+        return 90;
+      case CropRotation.sixOClock:
+        return 180;
+      case CropRotation.nineOClock:
+        return 270;
+    }
+  }
+
+  static CropRotation? fromDegrees(final int degrees) {
+    for (final CropRotation rotation in CropRotation.values) {
+      if (rotation.degrees == degrees) {
+        return rotation;
+      }
+    }
+    return null;
+  }
+
+  /// Returns the rotation rotated 90 degrees to the right.
+  CropRotation get rotateRight {
+    switch (this) {
+      case CropRotation.noon:
+        return CropRotation.threeOClock;
+      case CropRotation.threeOClock:
+        return CropRotation.sixOClock;
+      case CropRotation.sixOClock:
+        return CropRotation.nineOClock;
+      case CropRotation.nineOClock:
+        return CropRotation.noon;
+    }
+  }
+
+  /// Returns the rotation rotated 90 degrees to the left.
+  CropRotation get rotateLeft {
+    switch (this) {
+      case CropRotation.noon:
+        return CropRotation.nineOClock;
+      case CropRotation.nineOClock:
+        return CropRotation.sixOClock;
+      case CropRotation.sixOClock:
+        return CropRotation.threeOClock;
+      case CropRotation.threeOClock:
+        return CropRotation.noon;
+    }
+  }
+
+  /// Returns true if the rotated width is the initial height.
+  bool get isTilted {
+    switch (this) {
+      case CropRotation.noon:
+      case CropRotation.sixOClock:
+        return false;
+      case CropRotation.threeOClock:
+      case CropRotation.nineOClock:
+        return true;
+    }
+  }
+
+  /// Returns the offset as rotated.
+  Offset getRotatedOffset(
+    final Offset offset01,
+    final double noonWidth,
+    final double noonHeight,
+  ) {
+    switch (this) {
+      case CropRotation.noon:
+        return Offset(
+          noonWidth * offset01.dx,
+          noonHeight * offset01.dy,
+        );
+      case CropRotation.sixOClock:
+        return Offset(
+          noonWidth * (1 - offset01.dx),
+          noonHeight * (1 - offset01.dy),
+        );
+      case CropRotation.threeOClock:
+        return Offset(
+          noonWidth * offset01.dy,
+          noonHeight * (1 - offset01.dx),
+        );
+      case CropRotation.nineOClock:
+        return Offset(
+          noonWidth * (1 - offset01.dy),
+          noonHeight * offset01.dx,
+        );
+    }
+  }
+}


### PR DESCRIPTION
New files:
* `crop_rect.dart`: moved there code from controller, in order to avoid lint warnings
* `crop_rotation.dart`: 90 degree rotations.

Impacted files:
* `crop_controller.dart`: added rotation; made public `CropControllerValue`; refactored
* `crop_grid.dart`: added a paddingSize, in order to be able to detect the touch beyond the image (especially for image corners)
* `src/crop_image.dart`: added parameters paddingSize, touchSize and alwaysMove; refactored
* `crop_image.dart`: exported new file `CropRotation`
* `main.dart`: added rotation buttons; added "free" aspect ratio

Still to do:
* I struggled a lot with aspect ratio versus rotation, but I've preferred to PR something instead of getting crazy
* The picture gets refreshed every time the grid moves, and I wish the picture was refreshed only once
* in both cases I added `FIXME` comments