### PR TITLE
feat: aspect ratio is now kept after rotation

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -54,7 +54,7 @@ class _MyHomePageState extends State<MyHomePage> {
           IconButton(
             icon: const Icon(Icons.close),
             onPressed: () {
-              controller.rotation = CropRotation.noon;
+              controller.rotation = CropRotation.up;
               controller.crop = const Rect.fromLTRB(0.1, 0.1, 0.9, 0.9);
               controller.aspectRatio = 1.0;
             },

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,6 +2,7 @@ name: crop_image_example
 description: Example for crop_image.
 version: 1.0.1
 homepage: https://github.com/deakjahn/crop_image
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -11,6 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  crop_image:
+    path: ../
   cupertino_icons: ^1.0.5
 
 dev_dependencies:
@@ -18,9 +21,6 @@ dev_dependencies:
     sdk: flutter
 
   flutter_lints: ^2.0.1
-
-  crop_image:
-    path: ../
 
 flutter:
   uses-material-design: true

--- a/lib/src/crop_image.dart
+++ b/lib/src/crop_image.dart
@@ -199,7 +199,7 @@ class _CropImageState extends State<CropImage> {
   double _getWidth(final double maxWidth, final double maxHeight) {
     double imageRatio = _getImageRatio(maxWidth, maxHeight);
     final screenRatio = maxWidth / maxHeight;
-    if (controller.value.rotation.isTilted) {
+    if (controller.value.rotation.isSideways) {
       imageRatio = 1 / imageRatio;
     }
     if (imageRatio > screenRatio) {
@@ -211,7 +211,7 @@ class _CropImageState extends State<CropImage> {
   double _getHeight(final double maxWidth, final double maxHeight) {
     double imageRatio = _getImageRatio(maxWidth, maxHeight);
     final screenRatio = maxWidth / maxHeight;
-    if (controller.value.rotation.isTilted) {
+    if (controller.value.rotation.isSideways) {
       imageRatio = 1 / imageRatio;
     }
     if (imageRatio < screenRatio) {
@@ -432,13 +432,13 @@ class _RotatedImagePainter extends CustomPainter {
     double targetWidth = size.width;
     double targetHeight = size.height;
     double offset = 0;
-    if (rotation != CropRotation.noon) {
-      if (rotation.isTilted) {
+    if (rotation != CropRotation.up) {
+      if (rotation.isSideways) {
         final double tmp = targetHeight;
         targetHeight = targetWidth;
         targetWidth = tmp;
         offset = (targetWidth - targetHeight) / 2;
-        if (rotation == CropRotation.nineOClock) {
+        if (rotation == CropRotation.left) {
           offset = -offset;
         }
       }
@@ -453,7 +453,7 @@ class _RotatedImagePainter extends CustomPainter {
       Rect.fromLTWH(offset, offset, targetWidth, targetHeight),
       _paint,
     );
-    if (rotation != CropRotation.noon) {
+    if (rotation != CropRotation.up) {
       canvas.restore();
     }
   }

--- a/lib/src/crop_rotation.dart
+++ b/lib/src/crop_rotation.dart
@@ -3,23 +3,23 @@ import 'dart:ui';
 
 /// 90 degree rotations.
 enum CropRotation {
-  noon,
-  threeOClock,
-  sixOClock,
-  nineOClock,
+  up,
+  right,
+  down,
+  left,
 }
 
 extension CropRotationExtension on CropRotation {
   /// Returns the rotation in radians cw.
   double get radians {
     switch (this) {
-      case CropRotation.noon:
+      case CropRotation.up:
         return 0;
-      case CropRotation.threeOClock:
+      case CropRotation.right:
         return math.pi / 2;
-      case CropRotation.sixOClock:
+      case CropRotation.down:
         return math.pi;
-      case CropRotation.nineOClock:
+      case CropRotation.left:
         return 3 * math.pi / 2;
     }
   }
@@ -27,13 +27,13 @@ extension CropRotationExtension on CropRotation {
   /// Returns the rotation in degrees cw.
   int get degrees {
     switch (this) {
-      case CropRotation.noon:
+      case CropRotation.up:
         return 0;
-      case CropRotation.threeOClock:
+      case CropRotation.right:
         return 90;
-      case CropRotation.sixOClock:
+      case CropRotation.down:
         return 180;
-      case CropRotation.nineOClock:
+      case CropRotation.left:
         return 270;
     }
   }
@@ -50,39 +50,39 @@ extension CropRotationExtension on CropRotation {
   /// Returns the rotation rotated 90 degrees to the right.
   CropRotation get rotateRight {
     switch (this) {
-      case CropRotation.noon:
-        return CropRotation.threeOClock;
-      case CropRotation.threeOClock:
-        return CropRotation.sixOClock;
-      case CropRotation.sixOClock:
-        return CropRotation.nineOClock;
-      case CropRotation.nineOClock:
-        return CropRotation.noon;
+      case CropRotation.up:
+        return CropRotation.right;
+      case CropRotation.right:
+        return CropRotation.down;
+      case CropRotation.down:
+        return CropRotation.left;
+      case CropRotation.left:
+        return CropRotation.up;
     }
   }
 
   /// Returns the rotation rotated 90 degrees to the left.
   CropRotation get rotateLeft {
     switch (this) {
-      case CropRotation.noon:
-        return CropRotation.nineOClock;
-      case CropRotation.nineOClock:
-        return CropRotation.sixOClock;
-      case CropRotation.sixOClock:
-        return CropRotation.threeOClock;
-      case CropRotation.threeOClock:
-        return CropRotation.noon;
+      case CropRotation.up:
+        return CropRotation.left;
+      case CropRotation.left:
+        return CropRotation.down;
+      case CropRotation.down:
+        return CropRotation.right;
+      case CropRotation.right:
+        return CropRotation.up;
     }
   }
 
   /// Returns true if the rotated width is the initial height.
-  bool get isTilted {
+  bool get isSideways {
     switch (this) {
-      case CropRotation.noon:
-      case CropRotation.sixOClock:
+      case CropRotation.up:
+      case CropRotation.down:
         return false;
-      case CropRotation.threeOClock:
-      case CropRotation.nineOClock:
+      case CropRotation.right:
+      case CropRotation.left:
         return true;
     }
   }
@@ -94,22 +94,22 @@ extension CropRotationExtension on CropRotation {
     final double noonHeight,
   ) {
     switch (this) {
-      case CropRotation.noon:
+      case CropRotation.up:
         return Offset(
           noonWidth * offset01.dx,
           noonHeight * offset01.dy,
         );
-      case CropRotation.sixOClock:
+      case CropRotation.down:
         return Offset(
           noonWidth * (1 - offset01.dx),
           noonHeight * (1 - offset01.dy),
         );
-      case CropRotation.threeOClock:
+      case CropRotation.right:
         return Offset(
           noonWidth * offset01.dy,
           noonHeight * (1 - offset01.dx),
         );
-      case CropRotation.nineOClock:
+      case CropRotation.left:
         return Offset(
           noonWidth * (1 - offset01.dy),
           noonHeight * offset01.dx,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: crop_image
-description: An image cropper widget. Supports mobile, web and desktop.
+description: An image cropper widget, with 90-degree rotations. Supports mobile, web and desktop.
 version: 1.0.3
 homepage: https://github.com/deakjahn/crop_image
 


### PR DESCRIPTION
Impacted files:
* `crop_controller.dart`: `_adjustRatio` now accepts `null` ratio and optional `CropRotation` parameters; impact of refactored `CropRotation`
* `crop_image.dart`: impact of refactored `CropRotation`
* `crop_rotation.dart`: renamed `noon`, ... as `up`, ...; renamed `isTilted` as `isSideways`
* `main.dart`: impact of refactored `CropRotation`
* `example/pubspec.yaml`: refactored in order to avoid a warning
* `pubspec.yaml`: description larger than 80 chars, in order to improve pub.dev score

Now when we rotate, the aspect ratio is kept. If it was a (horizontal) 2:1, after rotation it is still a horizontal 2:1. Which means that the area is not the same.
If the aspect ratio is null, there are no further computations and the area is the same as before the rotation.

Therefore there's a bit of discrepancy. I don't know what users are expecting in general.
I coded according to my personal opinion: if I say 2:1 it means that I want a horizontal cropped area, regardless of the image rotation (e.g. for a profile picture). And if I say no aspect ratio and limit an area (e.g. a barcode), I want to keep this area.
Not 100% convinced...