### PR TITLE
fix: biggest crop area after rotation with aspect ratio

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -99,6 +99,10 @@ class _MyHomePageState extends State<MyHomePage> {
               child: const Text('2:1'),
             ),
             SimpleDialogOption(
+              onPressed: () => Navigator.pop(context, 1 / 2),
+              child: const Text('1:2'),
+            ),
+            SimpleDialogOption(
               onPressed: () => Navigator.pop(context, 4.0 / 3.0),
               child: const Text('4:3'),
             ),

--- a/lib/src/crop_controller.dart
+++ b/lib/src/crop_controller.dart
@@ -156,11 +156,24 @@ class CropController extends ValueNotifier<CropControllerValue> {
     if (aspectRatio == null) {
       return crop;
     }
+    final bool justRotated = rotation != null;
     rotation ??= value.rotation;
     final bitmapWidth =
         rotation.isSideways ? _bitmapSize.height : _bitmapSize.width;
     final bitmapHeight =
         rotation.isSideways ? _bitmapSize.width : _bitmapSize.height;
+    if (justRotated) {
+      // we've just rotated: in that case, biggest centered crop.
+      const center = Offset(.5, .5);
+      final width = bitmapWidth;
+      final height = bitmapHeight;
+      if (width / height > aspectRatio) {
+        final w = height * aspectRatio / bitmapWidth;
+        return Rect.fromCenter(center: center, width: w, height: 1);
+      }
+      final h = width / aspectRatio / bitmapHeight;
+      return Rect.fromCenter(center: center, width: 1, height: h);
+    }
     final width = crop.width * bitmapWidth;
     final height = crop.height * bitmapHeight;
     if (width / height > aspectRatio) {


### PR DESCRIPTION
Impacted files:
* `crop_controller.dart`: specific case for rotation, where we go to the biggest centered crop area if aspect ratio is specified
* `main.dart`: added a `1:2` aspect ratio, for tests