### PR TITLE
Don't dispose controllers passed from outside

### DIFF
--- a/lib/src/crop_image.dart
+++ b/lib/src/crop_image.dart
@@ -176,7 +176,11 @@ class _CropImageState extends State<CropImage> {
   @override
   void dispose() {
     controller.removeListener(onChange);
-    controller.dispose();
+
+    if (widget.controller == null) {
+      controller.dispose();
+    }
+
     _stream.removeListener(_streamListener);
 
     super.dispose();


### PR DESCRIPTION
This solves an issue where the `CropController` is disposed even if it is owned by another object.

Fixes #15