### PR TITLE
Fix croppedImage() on Flutter Web with the HTML web renderer.

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
 
   flutter_lints: ^2.0.1
 
-dev_dependency_overrides:
+dependency_overrides:
   crop_image:
     path: ../
 


### PR DESCRIPTION
Instead of using `canvas`, we can fetch pixels directly from the `Image`.
Moreover, since I have set the line length to be 80, there are some lines modified by the lint.
As for in `example/pubspec.yaml`, I think that using `dependency_overrides` is better than `dev_dependency_overrides`.