### PR TITLE
Fixed 'ImageDecoderCallback not found'

### DIFF
--- a/lib/src/crop_controller.dart
+++ b/lib/src/crop_controller.dart
@@ -349,7 +349,7 @@ class UiImageProvider extends ImageProvider<UiImageProvider> {
   Future<UiImageProvider> obtainKey(ImageConfiguration configuration) => SynchronousFuture<UiImageProvider>(this);
 
   @override
-  ImageStreamCompleter loadImage(UiImageProvider key, ImageDecoderCallback decode) => OneFrameImageStreamCompleter(_loadAsync(key));
+  ImageStreamCompleter loadImage(UiImageProvider key, ui.ImageDecoderCallback decode) => OneFrameImageStreamCompleter(_loadAsync(key));
 
   Future<ImageInfo> _loadAsync(UiImageProvider key) async {
     assert(key == this);


### PR DESCRIPTION
Fixed 'ImageDecoderCallback not found'

in updated version 'ImageDecoderCallback' is in 'dart:ui' it cannot be used directly