### PR TITLE
Fixed the display of blurry and jagged image.

### DIFF
--- a/lib/src/crop_controller.dart
+++ b/lib/src/crop_controller.dart
@@ -59,11 +59,9 @@ class CropController extends ValueNotifier<CropControllerValue> {
   void rotateLeft() => _rotate(left: true);
 
   void _rotate({required final bool left}) {
-    final CropRotation newRotation =
-        left ? value.rotation.rotateLeft : value.rotation.rotateRight;
-    final Offset newCenter = left
-        ? Offset(crop.center.dy, 1 - crop.center.dx)
-        : Offset(1 - crop.center.dy, crop.center.dx);
+    final CropRotation newRotation = left ? value.rotation.rotateLeft : value.rotation.rotateRight;
+    final Offset newCenter =
+        left ? Offset(crop.center.dy, 1 - crop.center.dx) : Offset(1 - crop.center.dy, crop.center.dx);
     value = CropControllerValue(
       aspectRatio,
       _adjustRatio(
@@ -124,18 +122,12 @@ class CropController extends ValueNotifier<CropControllerValue> {
     CropRotation rotation = CropRotation.up,
     double minimumImageSize = 100,
   })  : assert(aspectRatio != 0, 'aspectRatio cannot be zero'),
-        assert(defaultCrop.left >= 0 && defaultCrop.left <= 1,
-            'left should be 0..1'),
-        assert(defaultCrop.right >= 0 && defaultCrop.right <= 1,
-            'right should be 0..1'),
-        assert(
-            defaultCrop.top >= 0 && defaultCrop.top <= 1, 'top should be 0..1'),
-        assert(defaultCrop.bottom >= 0 && defaultCrop.bottom <= 1,
-            'bottom should be 0..1'),
-        assert(defaultCrop.left < defaultCrop.right,
-            'left must be less than right'),
-        assert(defaultCrop.top < defaultCrop.bottom,
-            'top must be less than bottom'),
+        assert(defaultCrop.left >= 0 && defaultCrop.left <= 1, 'left should be 0..1'),
+        assert(defaultCrop.right >= 0 && defaultCrop.right <= 1, 'right should be 0..1'),
+        assert(defaultCrop.top >= 0 && defaultCrop.top <= 1, 'top should be 0..1'),
+        assert(defaultCrop.bottom >= 0 && defaultCrop.bottom <= 1, 'bottom should be 0..1'),
+        assert(defaultCrop.left < defaultCrop.right, 'left must be less than right'),
+        assert(defaultCrop.top < defaultCrop.bottom, 'top must be less than bottom'),
         super(CropControllerValue(
           aspectRatio,
           defaultCrop,
@@ -156,10 +148,8 @@ class CropController extends ValueNotifier<CropControllerValue> {
     }
     final bool justRotated = rotation != null;
     rotation ??= value.rotation;
-    final bitmapWidth =
-        rotation.isSideways ? _bitmapSize.height : _bitmapSize.width;
-    final bitmapHeight =
-        rotation.isSideways ? _bitmapSize.width : _bitmapSize.height;
+    final bitmapWidth = rotation.isSideways ? _bitmapSize.height : _bitmapSize.width;
+    final bitmapHeight = rotation.isSideways ? _bitmapSize.width : _bitmapSize.height;
     if (justRotated) {
       // we've just rotated: in that case, biggest centered crop.
       const center = Offset(.5, .5);
@@ -218,6 +208,9 @@ class CropController extends ValueNotifier<CropControllerValue> {
     final bool tilted = rotation.isSideways;
     final double cropWidth;
     final double cropHeight;
+
+    final Paint _paint = Paint();
+
     if (tilted) {
       cropWidth = crop.width * image.height;
       cropHeight = crop.height * image.width;
@@ -265,39 +258,36 @@ class CropController extends ValueNotifier<CropControllerValue> {
         canvas.translate(-x, -y);
       }
     }
+    _paint.filterQuality = FilterQuality.high;
 
     canvas.drawImageRect(
-      image,
-      Rect.fromCenter(
-        center: cropCenter,
-        width: alternateWidth,
-        height: alternateHeight,
-      ),
-      Rect.fromLTWH(
-        0,
-        0,
-        alternateWidth * factor,
-        alternateHeight * factor,
-      ),
-      Paint()..filterQuality = quality,
-    );
+        image,
+        Rect.fromCenter(
+          center: cropCenter,
+          width: alternateWidth,
+          height: alternateHeight,
+        ),
+        Rect.fromLTWH(
+          0,
+          0,
+          alternateWidth * factor,
+          alternateHeight * factor,
+        ),
+        _paint);
 
     if (rotation != CropRotation.up) {
       canvas.restore();
     }
 
     //FIXME Picture.toImage() crashes on Flutter Web with the HTML renderer. Use CanvasKit or avoid this operation for now. https://github.com/flutter/engine/pull/20750
-    return await pictureRecorder
-        .endRecording()
-        .toImage((cropWidth * factor).round(), (cropHeight * factor).round());
+    return await pictureRecorder.endRecording().toImage((cropWidth * factor).round(), (cropHeight * factor).round());
   }
 
   /// Returns the image cropped with the current crop rectangle.
   ///
   /// You can provide the [quality] used in the resizing operation.
   /// Returns an [Image] asynchronously.
-  Future<Image> croppedImage(
-      {ui.FilterQuality quality = FilterQuality.high}) async {
+  Future<Image> croppedImage({ui.FilterQuality quality = FilterQuality.high}) async {
     return Image(
       image: UiImageProvider(await croppedBitmap(quality: quality)),
       fit: BoxFit.contain,
@@ -364,12 +354,10 @@ class UiImageProvider extends ImageProvider<UiImageProvider> {
   const UiImageProvider(this.image);
 
   @override
-  Future<UiImageProvider> obtainKey(ImageConfiguration configuration) =>
-      SynchronousFuture<UiImageProvider>(this);
+  Future<UiImageProvider> obtainKey(ImageConfiguration configuration) => SynchronousFuture<UiImageProvider>(this);
 
   @override
-  ImageStreamCompleter loadImage(
-          UiImageProvider key, ImageDecoderCallback decode) =>
+  ImageStreamCompleter loadImage(UiImageProvider key, ImageDecoderCallback decode) =>
       OneFrameImageStreamCompleter(_loadAsync(key));
 
   Future<ImageInfo> _loadAsync(UiImageProvider key) async {

--- a/lib/src/crop_image.dart
+++ b/lib/src/crop_image.dart
@@ -495,6 +495,7 @@ class _RotatedImagePainter extends CustomPainter {
       canvas.rotate(rotation.radians);
       canvas.translate(-targetWidth / 2, -targetHeight / 2);
     }
+    _paint.filterQuality = FilterQuality.high;
     canvas.drawImageRect(
       image,
       Rect.fromLTWH(0, 0, image.width.toDouble(), image.height.toDouble()),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: crop_image
 description: An image cropper widget, with 90-degree rotations. Supports mobile, web and desktop.
-version: 1.0.12
+version: 1.0.13
 homepage: https://github.com/deakjahn/crop_image
 
 environment:


### PR DESCRIPTION
Hi, I have tried using this library to crop images. It's a good library. But I see that the image is jaggy and blurry. Please add "_paint.filterQuality = FilterQuality.high;" to preserve the original image quality.

Edit file
`crop_image.dart > class _RotatedImagePainter`

`_paint.filterQuality = FilterQuality.high;`

Thanks.