### PR TITLE
Fixed should repaint when changing grid properties

### DIFF
--- a/lib/src/crop_grid.dart
+++ b/lib/src/crop_grid.dart
@@ -158,7 +158,11 @@ class _CropGridPainter extends CustomPainter {
   @override
   bool shouldRepaint(_CropGridPainter oldDelegate) =>
       oldDelegate.grid.crop != grid.crop || //
-      oldDelegate.grid.isMoving != grid.isMoving;
+      oldDelegate.grid.isMoving != grid.isMoving ||
+      oldDelegate.grid.cornerSize != grid.cornerSize ||
+      oldDelegate.grid.gridColor != grid.gridColor ||
+      oldDelegate.grid.gridCornerColor != grid.gridCornerColor ||
+      oldDelegate.grid.gridInnerColor != grid.gridInnerColor;
 
   @override
   bool hitTest(Offset position) => true;


### PR DESCRIPTION
This should fix issue https://github.com/deakjahn/crop_image/issues/49
It's very common to have usecase where we want to change grid properties after a loading or on user interaction. 
However, this is not possible. So as a hack for now, i'm setting the controller.crop = Rect.zero then update the crop + other properties so that it repaints and reflects the new color for the grid or grid corners.

Example:

<img width="386" alt="image" src="https://github.com/deakjahn/crop_image/assets/52201138/3a7dbd55-7678-4726-aaa0-ed2632918b64">
