### PR TITLE
feat: 52 - added an optional painter between the image and the crop grid

### DIFF
--- a/lib/src/crop_controller.dart
+++ b/lib/src/crop_controller.dart
@@ -186,14 +186,14 @@ class CropController extends ValueNotifier<CropControllerValue> {
   /// Returns the bitmap cropped with the current crop rectangle.
   ///
   /// [maxSize] is the maximum width or height you want.
-  /// [additionalPainter] is an optional painter on top of the cropped image;
+  /// [overlayPainter] is an optional painter on top of the cropped image;
   /// could be used for special effects on the cropped area.
   /// You can provide the [quality] used in the resizing operation.
   /// Returns an [ui.Image] asynchronously.
   Future<ui.Image> croppedBitmap({
     final double? maxSize,
     final ui.FilterQuality quality = FilterQuality.high,
-    final CustomPainter? additionalPainter,
+    final CustomPainter? overlayPainter,
   }) async =>
       getCroppedBitmap(
         maxSize: maxSize,
@@ -201,13 +201,13 @@ class CropController extends ValueNotifier<CropControllerValue> {
         crop: crop,
         rotation: value.rotation,
         image: _bitmap!,
-        additionalPainter: additionalPainter,
+        overlayPainter: overlayPainter,
       );
 
   /// Returns the bitmap cropped with parameters.
   ///
   /// [maxSize] is the maximum width or height you want.
-  /// [additionalPainter] is an optional painter on top of the cropped image;
+  /// [overlayPainter] is an optional painter on top of the cropped image;
   /// could be used for special effects on the cropped area.
   /// The [crop] `Rect` is normalized to (0, 0) x (1, 1).
   /// You can provide the [quality] used in the resizing operation.
@@ -217,7 +217,7 @@ class CropController extends ValueNotifier<CropControllerValue> {
     required final Rect crop,
     required final CropRotation rotation,
     required final ui.Image image,
-    final CustomPainter? additionalPainter,
+    final CustomPainter? overlayPainter,
   }) async {
     final ui.PictureRecorder pictureRecorder = ui.PictureRecorder();
     final Canvas canvas = Canvas(pictureRecorder);
@@ -295,7 +295,7 @@ class CropController extends ValueNotifier<CropControllerValue> {
 
     final double outputWidth = cropWidth * factor;
     final double outputHeight = cropHeight * factor;
-    additionalPainter?.paint(canvas, ui.Size(outputWidth, outputHeight));
+    overlayPainter?.paint(canvas, ui.Size(outputWidth, outputHeight));
 
     //FIXME Picture.toImage() crashes on Flutter Web with the HTML renderer. Use CanvasKit or avoid this operation for now. https://github.com/flutter/engine/pull/20750
     return await pictureRecorder.endRecording().toImage(
@@ -307,18 +307,18 @@ class CropController extends ValueNotifier<CropControllerValue> {
   /// Returns the image cropped with the current crop rectangle.
   ///
   /// You can provide the [quality] used in the resizing operation.
-  /// [additionalPainter] is an optional painter on top of the cropped image;
+  /// [overlayPainter] is an optional painter on top of the cropped image;
   /// could be used for special effects on the cropped area.
   /// Returns an [Image] asynchronously.
   Future<Image> croppedImage({
     ui.FilterQuality quality = FilterQuality.high,
-    final CustomPainter? additionalPainter,
+    final CustomPainter? overlayPainter,
   }) async {
     return Image(
       image: UiImageProvider(
         await croppedBitmap(
           quality: quality,
-          additionalPainter: additionalPainter,
+          overlayPainter: overlayPainter,
         ),
       ),
       fit: BoxFit.contain,

--- a/lib/src/crop_image.dart
+++ b/lib/src/crop_image.dart
@@ -110,7 +110,7 @@ class CropImage extends StatefulWidget {
   /// An optional painter between the image and the crop grid.
   ///
   /// Could be used for special effects on the cropped area.
-  final CustomPainter? additionalPainter;
+  final CustomPainter? overlayPainter;
 
   const CropImage({
     Key? key,
@@ -131,7 +131,7 @@ class CropImage extends StatefulWidget {
     this.minimumImageSize = 100,
     this.maximumImageSize = double.infinity,
     this.alwaysMove = false,
-    this.additionalPainter,
+    this.overlayPainter,
   })  : gridInnerColor = gridInnerColor ?? gridColor,
         gridCornerColor = gridCornerColor ?? gridColor,
         assert(gridCornerSize > 0, 'gridCornerSize cannot be zero'),
@@ -299,11 +299,11 @@ class _CropImageState extends State<CropImage> {
                     ),
                   ),
                 ),
-                if (widget.additionalPainter != null)
+                if (widget.overlayPainter != null)
                   SizedBox(
                     width: width,
                     height: height,
-                    child: CustomPaint(painter: widget.additionalPainter),
+                    child: CustomPaint(painter: widget.overlayPainter),
                   ),
                 SizedBox(
                   width: width + 2 * widget.paddingSize,

--- a/lib/src/crop_image.dart
+++ b/lib/src/crop_image.dart
@@ -107,6 +107,11 @@ class CropImage extends StatefulWidget {
   /// When `false`, moves when panning beyond corners but inside the crop rect.
   final bool alwaysMove;
 
+  /// An optional painter between the image and the crop grid.
+  ///
+  /// Could be used for special effects on the cropped area.
+  final CustomPainter? additionalPainter;
+
   const CropImage({
     Key? key,
     this.controller,
@@ -126,6 +131,7 @@ class CropImage extends StatefulWidget {
     this.minimumImageSize = 100,
     this.maximumImageSize = double.infinity,
     this.alwaysMove = false,
+    this.additionalPainter,
   })  : gridInnerColor = gridInnerColor ?? gridColor,
         gridCornerColor = gridCornerColor ?? gridColor,
         assert(gridCornerSize > 0, 'gridCornerSize cannot be zero'),
@@ -293,6 +299,12 @@ class _CropImageState extends State<CropImage> {
                     ),
                   ),
                 ),
+                if (widget.additionalPainter != null)
+                  SizedBox(
+                    width: width,
+                    height: height,
+                    child: CustomPaint(painter: widget.additionalPainter),
+                  ),
                 SizedBox(
                   width: width + 2 * widget.paddingSize,
                   height: height + 2 * widget.paddingSize,


### PR DESCRIPTION
Now there's an optional `CustomPainter` between the image and the crop grid.
A typical use case would be to handle receipts, where we need to crop the image but that's not enough: sometimes we need to bar some personal data too.

For instance:
| `CropImage` |`getCroppedBitmap` |
| -- | -- |
| ![Screenshot_1717592735](https://github.com/deakjahn/crop_image/assets/11576431/f566e524-c87a-497e-88a6-9a6b81aa5c52) | ![Screenshot_1717592857](https://github.com/deakjahn/crop_image/assets/11576431/9fb584ad-3047-4ef6-b936-54f7a2c2eb5d) |

Uploaded image: https://prices.openfoodfacts.net/img/0003/pRFjLvNol8.jpg