### PR TITLE
Add custom loading placeholder

### DIFF
--- a/lib/src/crop_image.dart
+++ b/lib/src/crop_image.dart
@@ -112,8 +112,12 @@ class CropImage extends StatefulWidget {
   /// Could be used for special effects on the cropped area.
   final CustomPainter? overlayPainter;
 
+  /// A widget rendered when the image is not ready.
+  /// Default is const CircularProgressIndicator.adaptive()
+  final Widget loadingPlaceholder;
+
   const CropImage({
-    Key? key,
+    super.key,
     this.controller,
     required this.image,
     this.gridColor = Colors.white70,
@@ -132,6 +136,7 @@ class CropImage extends StatefulWidget {
     this.maximumImageSize = double.infinity,
     this.alwaysMove = false,
     this.overlayPainter,
+    this.loadingPlaceholder = const CircularProgressIndicator.adaptive(),
   })  : gridInnerColor = gridInnerColor ?? gridColor,
         gridCornerColor = gridCornerColor ?? gridColor,
         assert(gridCornerSize > 0, 'gridCornerSize cannot be zero'),
@@ -140,8 +145,7 @@ class CropImage extends StatefulWidget {
         assert(gridThickWidth > 0, 'gridThickWidth cannot be zero'),
         assert(minimumImageSize > 0, 'minimumImageSize cannot be zero'),
         assert(maximumImageSize >= minimumImageSize,
-            'maximumImageSize cannot be less than minimumImageSize'),
-        super(key: key);
+            'maximumImageSize cannot be less than minimumImageSize');
 
   @override
   State<CropImage> createState() => _CropImageState();
@@ -274,7 +278,7 @@ class _CropImageState extends State<CropImage> {
         child: LayoutBuilder(
           builder: (BuildContext context, BoxConstraints constraints) {
             if (controller.getImage() == null) {
-              return const CircularProgressIndicator.adaptive();
+              return widget.loadingPlaceholder;
             }
             // we remove the borders
             final double maxWidth =


### PR DESCRIPTION
This PR adds a custom loading placeholder. 
Currently, we can not specify the loader when `controller.getImage()` is still null. It's using the default `const CircularProgressIndicator.adaptive()` which might not be aligned with everyone's design system. 
Related issue https://github.com/deakjahn/crop_image/issues/54