### PR TITLE
Added optional widgetOverlay to cropImage widget

### DIFF
--- a/lib/src/crop_image.dart
+++ b/lib/src/crop_image.dart
@@ -112,6 +112,11 @@ class CropImage extends StatefulWidget {
   /// Could be used for special effects on the cropped area.
   final CustomPainter? overlayPainter;
 
+  /// An optional widget between the image and the crop grid.
+  ///
+  /// Can be used to display any kind of widget on top of the image.
+  final Widget? overlayWidget;
+
   /// A widget rendered when the image is not ready.
   /// Default is const CircularProgressIndicator.adaptive()
   final Widget loadingPlaceholder;
@@ -136,6 +141,7 @@ class CropImage extends StatefulWidget {
     this.maximumImageSize = double.infinity,
     this.alwaysMove = false,
     this.overlayPainter,
+    this.overlayWidget,
     this.loadingPlaceholder = const CircularProgressIndicator.adaptive(),
   })  : gridInnerColor = gridInnerColor ?? gridColor,
         gridCornerColor = gridCornerColor ?? gridColor,
@@ -285,6 +291,12 @@ class _CropImageState extends State<CropImage> {
                     width: width,
                     height: height,
                     child: CustomPaint(painter: widget.overlayPainter),
+                  ),
+                if (widget.overlayWidget != null)
+                  SizedBox(
+                    width: width,
+                    height: height,
+                    child: widget.overlayWidget,
                   ),
                 SizedBox(
                   width: width + 2 * widget.paddingSize,


### PR DESCRIPTION
I required a standard widget overlay rather than a custom painter in the render stack, so I added it. It's very simple, minimal change.

It  effectively makes `overlayPainter` redundant given you can just add a `CustomPaint()` widget to `widgetOverlay`, but that would be a breaking change so I kept it in.